### PR TITLE
remove typing for python 3.5 and above for python 3.8 support

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name=yaml-config
-version=0.1.4
+version=0.1.5
 description=Python client for reading yaml based config files
 author=Paul Munday, Fable Turas
 author_email=paul@paulmunday.net, fable@rainsoftware.tech
@@ -17,12 +17,13 @@ classifiers =
 	Programming Language :: Python :: 3.5
 	Programming Language :: Python :: 3.6
 	Programming Language :: Python :: 3.7
+	Programming Language :: Python :: 3.8
 [options]
 packages = find:
 include_package_data = True
 zip_safe = False
 install_requires =
 	PyYAML>=3.13
-	typing>=3.6.1
+	typing>=3.6.1; python_version<'3.5'
 [bdist_wheel]
 universal = 1


### PR DESCRIPTION
@fablet This is related to https://github.com/GreenBuildingRegistry/usaddress-scourgify/pull/13